### PR TITLE
add compile req to test rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: bazuara <bazuara@student.42madrid.com>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/02/04 17:08:31 by sacorder          #+#    #+#              #
-#    Updated: 2024/06/27 10:35:04 by bazuara          ###   ########.fr        #
+#    Updated: 2024/06/28 11:19:47 by bazuara          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,7 +40,7 @@ clean:
 fclean: clean
 	$(RM) $(NAME)
 # start the server and redirects all outputs to null
-start_server:
+start_server: $(NAME)
 	@./$(NAME) 2> /dev/null 1> /dev/null &
 
 test: start_server


### PR DESCRIPTION
A missing req on the test rule is added to ensure the binary is compiled when running tests