### PR TITLE
Timeout cgi

### DIFF
--- a/CGI/long_test.py
+++ b/CGI/long_test.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+from art import *
+import time
+
+time.sleep(10)
+
+
+Art=text2art("Demo",font='block',chr_ignore=True)
+print(Art)

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -120,7 +120,7 @@ void CGIHandler::waitForChildProcess(pid_t pid, int pipefd[])
     if (result == 0)
     {
         // Child process is still running
-        sleep(5); // Wait for 5 seconds
+        sleep(1); // Wait for 1 seconds
         result = waitpid(pid, &status, WNOHANG);
         if (result == 0)
         {

--- a/srcs/CgiHandler.cpp
+++ b/srcs/CgiHandler.cpp
@@ -115,7 +115,21 @@ void CGIHandler::setCGIEnvironment()
 void CGIHandler::waitForChildProcess(pid_t pid, int pipefd[])
 {
     int status;
-    waitpid(pid, &status, 0);
+    pid_t result = waitpid(pid, &status, WNOHANG);
+
+    if (result == 0)
+    {
+        // Child process is still running
+        sleep(5); // Wait for 5 seconds
+        result = waitpid(pid, &status, WNOHANG);
+        if (result == 0)
+        {
+            // Child process is still running after timeout
+            kill(pid, SIGKILL); // Kill the child process
+            outputData = "Error: Timeout";
+            return;
+        }
+    }
 
     if (WIFEXITED(status))
     {

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -7,9 +7,13 @@ int main()
 
 	// test cgi
 	std::cout << "CGI TEST" << std::endl;
-	CGIHandler cgiHandler("CGI/test.py");
-	cgiHandler.handleRequest();
-	std::cout << "CGI TEST: Begining of output data -> " << cgiHandler.getOutputData() << "<- End of output data." << std::endl;
+	CGIHandler cgiHandler1("CGI/test.py");
+	cgiHandler1.handleRequest();
+	std::cout << "CGI TEST: Begining of output data 1 -> " << cgiHandler1.getOutputData() << "<- End of output data 1." << std::endl;
+
+	CGIHandler cgiHandler2("CGI/long_test.py");
+	cgiHandler2.handleRequest();
+	std::cout << "CGI TEST: Begining of output data 2 -> " << cgiHandler2.getOutputData() << "<- End of output data 2." << std::endl;
 	std::cout << "CGI TEST END" << std::endl;
 	// end of cgi test
 


### PR DESCRIPTION
add a timeout for cgi processes, if child is still running after 1 second, it kills the child and return a string containing only with Error: Timeout